### PR TITLE
Improving the site navigation

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -34,13 +34,13 @@
     }
 
     header {
-        text-align: center;
         margin-block-end: 3rem;
         margin-block-start: 1.5rem;
     }
 
     header nav {
-        display: inline-flex;
+        display: flex;
+        align-items: baseline;
         flex-wrap: wrap;
         column-gap: 1rem;
         row-gap: 0.5rem;
@@ -58,7 +58,7 @@
         inset-inline-start: 1rem;
     }
 
-    header nav a[aria-current="page"] {
+    a[aria-current="page"] {
         text-decoration: none;
     }
 
@@ -68,6 +68,135 @@
 }
 
 @layer components {
+    .site-title {
+        font-size: 1.25rem;
+        font-weight: 700;
+        color: Black;
+    }
+
+    @media screen and (min-width: 40rem) {
+        .site-title {
+            font-size: 1rem;
+        }
+    }
+
+    .language-switcher {
+        display: flex;
+        justify-content: center;
+        gap: 0.5em;
+    }
+
+    .language-switcher :any-link {
+        color: Black;
+        font-weight: 500;
+    }
+
+    nav-overlay:not(:defined) {
+        display: contents;
+
+    }
+    nav-overlay:not(:defined) :where([slot], .federal-mps) {
+        display: none;
+    }
+
+    nav-overlay:defined {
+        display: inline-block;
+    }
+
+    @media screen and (min-width: 40rem) {
+        nav-overlay:defined {
+            margin-inline-start: auto;
+        }
+    }
+
+    :root:has(nav-overlay:state(open)) {
+        overflow: hidden;
+        opacity: 0;
+        transition: opacity 200ms ease-in;
+    }
+
+    nav-overlay::part(overlay) {
+        transition:
+            opacity 300ms ease-in-out,
+            overlay 0s ease-in-out allow-discrete;
+    }
+
+    nav-overlay :any-link {
+        transition: opacity 200ms ease-in-out;
+        transition-delay: 300ms;
+        transition-delay: calc(100ms + 50ms * sibling-index());
+    }
+
+    nav-overlay::part(overlay):modal {
+        justify-content: center;
+        justify-items: center;
+        align-items: center;
+        box-sizing: border-box;
+        display: grid;
+        align-content: safe center;
+        grid-gap: 8px;
+        padding: 36px;
+        inset: 0;
+        max-block-size: 100%;
+        max-inline-size: 100%;
+        block-size: 100%;
+        inline-size: 100%;
+        border: 0;
+    }
+
+    nav-overlay::part(button) {
+        font: inherit;
+        font-weight: 500;
+        background-color: Black;
+        color: White;
+        padding-block: 4px;
+        padding-inline: 8px;
+        border: 2px solid Black;
+        border-radius: 4px;
+        cursor: pointer;
+
+        transition-property: background-color, color;
+        transition-duration: 150ms;
+        transition-timing-function: ease-in-out;
+    }
+
+    nav-overlay::part(button):hover {
+        background-color: White;
+        color: Black;
+    }
+
+    nav-overlay::part(button):focus-visible {
+        outline: 2px solid RoyalBlue;
+        outline-offset: 2px;
+    }
+
+
+    nav-overlay::part(close-button) {
+        position: fixed;
+        inset-block-start: 48px;
+        inset-inline-end: 48px;
+
+        transition:
+            background-color 150ms,
+            color 150ms,
+            opacity 200ms 300ms;
+        transition-timing-function: ease-in-out;
+    }
+
+    nav-overlay:defined :any-link {
+        font-weight: 600;
+        font-size: 1.25rem;
+        color: Black;
+    }
+
+    @starting-style {
+        nav-overlay::part(close-button),
+        nav-overlay::part(overlay):modal,
+        nav-overlay :any-link {
+            opacity: 0;
+        }
+    }
+
     .member-cards-grid {
         display: grid;
         list-style: none;

--- a/public/nav-overlay-element.js
+++ b/public/nav-overlay-element.js
@@ -1,0 +1,47 @@
+class NavOverlayElement extends HTMLElement {
+    get #dialog() { return this.shadowRoot.querySelector("dialog"); }
+
+    #internals = this.attachInternals();
+    constructor() {
+        super();
+        this.attachShadow({ mode: "open" });
+
+        this.shadowRoot.innerHTML = `
+            <style>
+                ::slotted(span) { pointer-events: none; }
+                ::slotted(svg) { fill: currentColor; width: 1em; height: 1em; position: relative; top: -0.1em; vertical-align: middle; }
+            </style>
+            <button commandfor=overlay command=show-modal part="button open-button">
+                <slot name=open-button-label></slot>
+                <slot name=open-button-icon aria-hidden=true></slot>
+            </button>
+            <dialog id=overlay part=overlay>
+                <button commandfor=overlay command=close part="button close-button">
+                    <slot name=close-button-label></slot>
+                    <slot name=close-button-icon aria-hidden=true></slot>
+                </button>
+                <slot></slot>
+            </dialog>
+        `;
+
+        if (!("command" in HTMLButtonElement.prototype)) {
+            this.shadowRoot.addEventListener("click", this);
+        }
+
+        this.shadowRoot.addEventListener("toggle", this, true);
+    }
+
+    handleEvent(event) {
+        switch (event.type) {
+            case "click":
+                if (event.target?.part.contains("open-button")) this.#dialog.showModal();
+                if (event.target?.part.contains("close-button")) this.#dialog.close();
+                break;
+            case "toggle":
+                this.#internals.states[event.newState === "open" ? "add" : "delete"]("open");
+                break;
+        }
+    }
+}
+
+customElements.define("nav-overlay", NavOverlayElement);

--- a/translations/en.json
+++ b/translations/en.json
@@ -142,6 +142,8 @@
     "allParties": "All parties",
 
     "skipToContent": "Skip to content",
+    "close": "Close",
+    "whoElse": "Who else is a landlord?",
 
     "provinces": {
 		"ab": "Alberta",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -140,6 +140,8 @@
     "allParties": "Toutes les parties",
 
     "skipToContent": "Passer au contenu",
+    "close": "Fermer",
+    "whoElse": "Qui d’autre est propriétaire?",
 
     "provinces": {
 		"ab": "Alberta",

--- a/views/_layouts/base.pug
+++ b/views/_layouts/base.pug
@@ -11,28 +11,43 @@ html.no-js(lang=`${lang}-ca`)
       link(rel="stylesheet" href="/main.css")
       link(rel="stylesheet" href="/index.css")
       link(rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible+Mono:ital,wght@0,200..800;1,200..800&family=Atkinson+Hyperlegible+Next:ital,wght@0,200..800;1,200..800&display=swap")
+      script(src="/nav-overlay-element.js")
   body
+    mixin nav-link
+      a(aria-current=attributes.href === currentPath && "page")&attributes(attributes)
+        block
+
     a(href="#content").visually-hidden.skip-to-content=t("skipToContent")
-    case lang
-      when "en": a.switch-language(href=currentPath.startsWith("/en/about") ? "/fr/a-propos" : currentPath.replace("en", "fr")) Français
-      when "fr": a.switch-language(href=currentPath.startsWith("/fr/a-propos") ? "/en/about" : currentPath.replace("fr", "en")) English
+    .language-switcher
+      +nav-link(href=currentPath.startsWith("/fr/a-propos") ? "/en/about" : currentPath.replace("fr", "en"))
+        span(aria-hidden="true") EN
+        .visually-hidden English
+      +nav-link(href=currentPath.startsWith("/en/about") ? "/fr/a-propos" : currentPath.replace("en", "fr"))
+        span(aria-hidden="true") FR
+        .visually-hidden Français
     header
       nav
-        mixin nav-link
-          a(aria-current=attributes.href === currentPath && "page")&attributes(attributes)
-            block
-        +nav-link(href=`/${lang}`)=t("home")
+        +nav-link(href=`/${lang}`).site-title=t("siteTitle")
         +nav-link(href=`/${lang}/${lang === "en" ? "about" : "a-propos"}`)=t("about")
-        +nav-link(href=`/${lang}/bc`) BC MLAs
-        +nav-link(href=`/${lang}/ab`) Alberta MLAs
-        +nav-link(href=`/${lang}/sk`) Saskatchewan MLAs
-        +nav-link(href=`/${lang}/mb`) Manitoba MLAs
-        +nav-link(href=`/${lang}/on`) Ontario MPPs
-        +nav-link(href=`/${lang}/qc`) Quebec MNAs
-        +nav-link(href=`/${lang}/ns`) Nova Scotia MLAs
-        +nav-link(href=`/${lang}/nb`) New Brunswick MLAs
-        +nav-link(href=`/${lang}/pe`) PEI MLAs
-        +nav-link(href=`/${lang}/nl`) Newfoundland & Labrador MHAs
+        nav-overlay
+          span(slot="open-button-label")=t("whoElse")
+          span(slot="close-button-label")=t("close")
+          // Font Awesome Free v7.1.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.
+          svg(slot="open-button-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" aria-hidden="true" focusable="false")
+            path(fill=currentColor d="M352 128C352 110.3 337.7 96 320 96C302.3 96 288 110.3 288 128L288 288L128 288C110.3 288 96 302.3 96 320C96 337.7 110.3 352 128 352L288 352L288 512C288 529.7 302.3 544 320 544C337.7 544 352 529.7 352 512L352 352L512 352C529.7 352 544 337.7 544 320C544 302.3 529.7 288 512 288L352 288L352 128z")
+          svg(slot="close-button-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640" aria-hidden="true" focusable="false")
+            path(fill=currentColor d="M183.1 137.4C170.6 124.9 150.3 124.9 137.8 137.4C125.3 149.9 125.3 170.2 137.8 182.7L275.2 320L137.9 457.4C125.4 469.9 125.4 490.2 137.9 502.7C150.4 515.2 170.7 515.2 183.2 502.7L320.5 365.3L457.9 502.6C470.4 515.1 490.7 515.1 503.2 502.6C515.7 490.1 515.7 469.8 503.2 457.3L365.8 320L503.1 182.6C515.6 170.1 515.6 149.8 503.1 137.3C490.6 124.8 470.3 124.8 457.8 137.3L320.5 274.7L183.1 137.4z")
+          +nav-link(href=`/${lang}`).federal-mps Federal MPs
+          +nav-link(href=`/${lang}/bc`) BC MLAs
+          +nav-link(href=`/${lang}/ab`) Alberta MLAs
+          +nav-link(href=`/${lang}/sk`) Saskatchewan MLAs
+          +nav-link(href=`/${lang}/mb`) Manitoba MLAs
+          +nav-link(href=`/${lang}/on`) Ontario MPPs
+          +nav-link(href=`/${lang}/qc`) Quebec MNAs
+          +nav-link(href=`/${lang}/ns`) Nova Scotia MLAs
+          +nav-link(href=`/${lang}/nb`) New Brunswick MLAs
+          +nav-link(href=`/${lang}/pe`) PEI MLAs
+          +nav-link(href=`/${lang}/nl`) Newfoundland & Labrador MHAs
     main#content
       block main
     footer.contact


### PR DESCRIPTION
This adds a custom element called `<nav-overlay>` which takes nav links in the banner and shoves them into an overlay (`<dialog>` element) which takes over the screen at all viewport sizes (it’s complicated if we want to provide different experiences).

- This uses [Invoker Commands](https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API) for the buttons, but instead of using a polyfill for it in unsupporting browsers, I’ve just wired up the button the old fashioned way.
- Changes the “Home” button back to the site title. It’s important to have the site title in the body-scoped `<header>` element as this is [the `banner` landmark](https://w3c.github.io/aria/#banner) for assistive tech.
- A link for “Federal MPs” is in the overlay too.
- If using a Chromium-based browser, you’ll notice I had a little fun with the entrance animation. I can remove this if it’s too distracting.

To do before this is ready: 

- [x] Localize the “Close” button label
- [x] Localize the “Who else is a landlord?” (open) button label
- [x] Perhaps emphasize the “Is My MP a Landlord?” link text to make it stand out more as the site name.
- [x] Fix the layout within the banner. I mocked up a different layout which might be worth using. Some attention to mobile will be necessary.